### PR TITLE
fsbl: inject an appropriate DTS string for the microchip expansion board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,12 @@ fsbl/ux00boot.o: ux00boot/ux00boot.c
 fsbl.elf: $(LIB_FS_O) ux00_fsbl.lds
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(filter %.o,$^) -T$(filter %.lds,$^)
 
-fsbl/dtb.o: fsbl/ux00_fsbl.dtb
+fsbl/dtb.o: fsbl/ux00_fsbl.dtb fsbl/ux00_fsbl_microsemi.dtb
 
 zsbl/start.o: zsbl/ux00_zsbl.dtb
+
+fsbl/ux00_fsbl_microsemi.dtb: fsbl/ux00_fsbl.dts fsbl/ux00_fsbl_microsemi.dts
+	cat $^ | dtc - -o $@ -O dtb
 
 %.bin: %.elf
 	$(OBJCOPY) -O binary $^ $@
@@ -78,7 +81,7 @@ zsbl/start.o: zsbl/ux00_zsbl.dtb
 	$(OBJDUMP) -S $^ > $@
 
 %.dtb: %.dts
-	dtc $^ -o $@ -O dtb
+	dtc $< -o $@ -O dtb
 
 %.o: %.S
 	$(CC) $(CFLAGS) $(CCASFLAGS) -c $< -o $@

--- a/fsbl/dtb.S
+++ b/fsbl/dtb.S
@@ -6,3 +6,7 @@
   .globl own_dtb
 own_dtb:
   .incbin "fsbl/ux00_fsbl.dtb"
+
+  .globl microsemi_dtb
+microsemi_dtb:
+  .incbin "fsbl/ux00_fsbl_microsemi.dtb"

--- a/fsbl/ux00_fsbl.dts
+++ b/fsbl/ux00_fsbl.dts
@@ -396,28 +396,6 @@
 			reg-names = "control";
 		};
 
-		/* MicroSemi HiFive Unleashed Expansion board */
-		pci@2030000000 {
-			#address-cells = <3>;
-			#interrupt-cells = <1>;
-			#size-cells = <2>;
-			compatible = "ms-pf,axi-pcie-host";
-			device_type = "pci";
-			bus-range = <0x01 0x7f>;
-			interrupt-map = <0 0 0 1 &ms_pcie_intc 1 0 0 0 2 &ms_pcie_intc 2 0 0 0 3 &ms_pcie_intc 3 0 0 0 4 &ms_pcie_intc 4>;
-			interrupt-map-mask = <0 0 0 7>;
-			interrupt-parent = <&L4>;
-			interrupts = <32>;
-			ranges = <0x2000000 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000>;
-			reg = <0x20 0x30000000 0x0 0x4000000 0x20 0x0 0x0 0x100000>;
-			reg-names = "control", "apb";
-			ms_pcie_intc: interrupt-controller {
-				#address-cells = <0>;
-				#interrupt-cells = <1>;
-				interrupt-controller;
-			};
-		};
-
 		L53: pinctrl@10080000 {
 			compatible = "sifive,pinctrl0";
 			reg = <0x0 0x10080000 0x0 0x1000>;

--- a/fsbl/ux00_fsbl_microsemi.dts
+++ b/fsbl/ux00_fsbl_microsemi.dts
@@ -1,0 +1,24 @@
+/ {
+	soc {
+                pci@2030000000 {
+                        #address-cells = <3>;
+                        #interrupt-cells = <1>;
+                        #size-cells = <2>;
+                        compatible = "ms-pf,axi-pcie-host";
+                        device_type = "pci";
+                        bus-range = <0x01 0x7f>;
+                        interrupt-map = <0 0 0 1 &ms_pcie_intc 1 0 0 0 2 &ms_pcie_intc 2 0 0 0 3 &ms_pcie_intc 3 0 0 0 4 &ms_pcie_intc 4>;
+                        interrupt-map-mask = <0 0 0 7>;
+                        interrupt-parent = <&L4>;
+                        interrupts = <32>;
+                        ranges = <0x2000000 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000>;
+                        reg = <0x20 0x30000000 0x0 0x4000000 0x20 0x0 0x0 0x100000>;
+                        reg-names = "control", "apb";
+                        ms_pcie_intc: interrupt-controller {
+                                #address-cells = <0>;
+                                #interrupt-cells = <1>;
+                                interrupt-controller;
+                        };
+                };
+	};
+};


### PR DESCRIPTION
Unfortunately, these boards shipped without an embedded DTB of their own.
Detect these boards by the absence of a ChipLink DTB and the presence of
the Microsemi PCIe controller in ECAM space.

When detected, switch the board DTB for a DTB which includes the Microsemi
root complex.