### PR TITLE
Dual-license Apache or GPL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,12 @@
+Copyright (c) 2018 SiFive, Inc
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This code (Freedom-u540-c000-bootloader) may be used, at your choice,
+under the terms of the GNU General Public License version 2.0 or later,
+available at https://www.gnu.org/licenses, or the Apache 2.0 license,
+attached below.
+
 
                                  Apache License
                            Version 2.0, January 2004

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-# Copyright 2018 SiFive, Inc
+# Copyright (c) 2018 SiFive, Inc
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 # See the file LICENSE for further information
 
 CROSSCOMPILE?=riscv64-unknown-elf-

--- a/clkutils/clkutils.c
+++ b/clkutils/clkutils.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include "clkutils.h"

--- a/clkutils/clkutils.h
+++ b/clkutils/clkutils.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _LIBRARIES_CLKUTILS_H

--- a/ememoryotp/ememoryotp.c
+++ b/ememoryotp/ememoryotp.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <stdint.h>

--- a/ememoryotp/ememoryotp.h
+++ b/ememoryotp/ememoryotp.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef EMEMORY_OTP_H

--- a/encoding.h
+++ b/encoding.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef RISCV_CSR_ENCODING_H

--- a/fdt/fdt.c
+++ b/fdt/fdt.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <stdint.h>

--- a/fdt/fdt.h
+++ b/fdt/fdt.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef FDT_H

--- a/fsbl/ddrregs.h
+++ b/fsbl/ddrregs.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <stdint.h>

--- a/fsbl/dtb.S
+++ b/fsbl/dtb.S
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
   .section .data

--- a/fsbl/dtb1.0.S
+++ b/fsbl/dtb1.0.S
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
   .section .data

--- a/fsbl/main.c
+++ b/fsbl/main.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include "encoding.h"

--- a/fsbl/regconfig-ctl.h
+++ b/fsbl/regconfig-ctl.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #define               DENALI_CTL_00_DATA 0x00000a00

--- a/fsbl/regconfig-phy.h
+++ b/fsbl/regconfig-phy.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #define               DENALI_PHY_00_DATA 0x31706542

--- a/fsbl/start.S
+++ b/fsbl/start.S
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <sifive/bits.h>

--- a/fsbl/ux00_fsbl.dts
+++ b/fsbl/ux00_fsbl.dts
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 /dts-v1/;

--- a/fsbl/ux00ddr.h
+++ b/fsbl/ux00ddr.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_UX00DDR_H

--- a/gpt/gpt.c
+++ b/gpt/gpt.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <stdbool.h>

--- a/gpt/gpt.h
+++ b/gpt/gpt.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _LIBRARIES_GPT_H

--- a/lib/memcpy.c
+++ b/lib/memcpy.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 /* Copyright (c) 2017  SiFive Inc. All rights reserved.

--- a/lib/memset.S
+++ b/lib/memset.S
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 /* Copyright (c) 2017  SiFive Inc. All rights reserved.

--- a/lib/strcmp.S
+++ b/lib/strcmp.S
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 /* Copyright (c) 2017  SiFive Inc. All rights reserved.

--- a/lib/strcpy.c
+++ b/lib/strcpy.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 /* Copyright (c) 2017  SiFive Inc. All rights reserved.

--- a/lib/strlen.c
+++ b/lib/strlen.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 /* Copyright (c) 2017  SiFive Inc. All rights reserved.

--- a/memory.lds
+++ b/memory.lds
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 MEMORY

--- a/sd/sd.c
+++ b/sd/sd.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <sifive/platform.h>

--- a/sd/sd.h
+++ b/sd/sd.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _LIBRARIES_SD_H

--- a/sifive/barrier.h
+++ b/sifive/barrier.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef SIFIVE_BARRIER

--- a/sifive/bits.h
+++ b/sifive/bits.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _RISCV_BITS_H

--- a/sifive/const.h
+++ b/sifive/const.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_CONST_H

--- a/sifive/devices/ccache.h
+++ b/sifive/devices/ccache.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_CCACHE_H

--- a/sifive/devices/clint.h
+++ b/sifive/devices/clint.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_CLINT_H

--- a/sifive/devices/ememoryotp.h
+++ b/sifive/devices/ememoryotp.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _EMEMORYOTP_H

--- a/sifive/devices/gpio.h
+++ b/sifive/devices/gpio.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_GPIO_H

--- a/sifive/devices/i2c.h
+++ b/sifive/devices/i2c.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_I2C_H

--- a/sifive/devices/spi.h
+++ b/sifive/devices/spi.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_SPI_H

--- a/sifive/devices/uart.h
+++ b/sifive/devices/uart.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_UART_H

--- a/sifive/devices/ux00prci.h
+++ b/sifive/devices/ux00prci.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_UX00PRCI_H

--- a/sifive/platform.h
+++ b/sifive/platform.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _SIFIVE_PLATFORM_H

--- a/sifive/smp.h
+++ b/sifive/smp.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef SIFIVE_SMP

--- a/spi/spi.c
+++ b/spi/spi.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <stdint.h>

--- a/spi/spi.h
+++ b/spi/spi.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _DRIVERS_SPI_H

--- a/uart/uart.c
+++ b/uart/uart.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <stdatomic.h>

--- a/uart/uart.h
+++ b/uart/uart.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _DRIVERS_UART_H

--- a/ux00_fsbl.lds
+++ b/ux00_fsbl.lds
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 OUTPUT_ARCH("riscv")

--- a/ux00_zsbl.lds
+++ b/ux00_zsbl.lds
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 OUTPUT_ARCH("riscv")

--- a/ux00boot/ux00boot.c
+++ b/ux00boot/ux00boot.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <stdatomic.h>

--- a/ux00boot/ux00boot.h
+++ b/ux00boot/ux00boot.h
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #ifndef _LIBRARIES_UX00BOOT_H

--- a/zsbl/main.c
+++ b/zsbl/main.c
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <sifive/barrier.h>

--- a/zsbl/start.S
+++ b/zsbl/start.S
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 #include <sifive/bits.h>

--- a/zsbl/ux00_zsbl.dts
+++ b/zsbl/ux00_zsbl.dts
@@ -1,5 +1,6 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright (c) 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
 /dts-v1/;


### PR DESCRIPTION
Signed-off-by: Troy Benjegerdes <troy.benjegerdes@sifive.com>

Per request from coreboot developers:

> Can you directly use files licensed under:  in coreboot? (i.e., do you consider this a GPL-compatible license)
Coreboot is licensed under GPL2-only (not GPL2+ which is apache 2 compatible), so if you could dual-license it under GPL2 or BSD that would be helpful.