### PR TITLE
Fix functions taking no arguments

### DIFF
--- a/clkutils/clkutils.h
+++ b/clkutils/clkutils.h
@@ -16,7 +16,7 @@
 // https://stackoverflow.com/a/23699777/7433423
 
 
-inline uint64_t clkutils_read_mtime() {
+inline uint64_t clkutils_read_mtime(void) {
 #if __riscv_xlen == 32
   uint32_t mtime_hi_0;
   uint32_t mtime_lo;
@@ -33,7 +33,7 @@ inline uint64_t clkutils_read_mtime() {
 #endif
 }
 
-inline static uint64_t clkutils_read_mcycle() {
+inline static uint64_t clkutils_read_mcycle(void) {
 #if __riscv_xlen == 32
   uint32_t mcycle_hi_0;
   uint32_t mcycle_lo;

--- a/sifive/devices/ccache.h
+++ b/sifive/devices/ccache.h
@@ -53,8 +53,8 @@ static inline uint64_t ccache_stride(uint64_t base_addr) {
 }
 
 // Block memory access until operation completed
-static inline void ccache_barrier_0() { asm volatile("fence rw, io" : : : "memory" ); }
-static inline void ccache_barrier_1() { asm volatile("fence io, rw" : : : "memory" ); }
+static inline void ccache_barrier_0(void) { asm volatile("fence rw, io" : : : "memory" ); }
+static inline void ccache_barrier_1(void) { asm volatile("fence io, rw" : : : "memory" ); }
 
 // flush64 takes a byte-aligned address, while flush32 takes an address right-shifted by 4
 static inline void ccache_flush64(uint64_t base_addr, uint64_t flush_addr) {


### PR DESCRIPTION
In C, unlike C++, "int f();" declares a function that
takes an unspecified number of arguments, whereas "int f(void);"
declares a function that takes no arguments.