### PR TITLE
Bootrom challenge

### DIFF
--- a/clkutils/clkutils.h
+++ b/clkutils/clkutils.h
@@ -61,7 +61,7 @@ inline static uint64_t clkutils_read_mcycle(void) {
 // at all. So this function delays AT LEAST delay_ns.
 inline void clkutils_delay_ns(int delay_ns) {
   uint64_t now = clkutils_read_mtime();
-  uint64_t then = now + delay_ns / RTC_PERIOD_NS + 1;
+  uint64_t then = now + delay_ns / RTC_PERIOD_NS;
 
   do {
     now = clkutils_read_mtime();

--- a/lib/memcpy.c
+++ b/lib/memcpy.c
@@ -63,15 +63,16 @@ small:
 	  long b6 = *lb++;
 	  long b7 = *lb++;
 	  long b8 = *lb++;
-	  *la++ = b0;
-	  *la++ = b1;
-	  *la++ = b2;
-	  *la++ = b3;
-	  *la++ = b4;
-	  *la++ = b5;
-	  *la++ = b6;
-	  *la++ = b7;
-	  *la++ = b8;
+	  la += 9;
+	  la[-9] = b0;
+	  la[-8] = b1;
+	  la[-7] = b2;
+	  la[-6] = b3;
+	  la[-5] = b4;
+	  la[-4] = b5;
+	  la[-3] = b6;
+	  la[-2] = b7;
+	  la[-1] = b8;
 	}
     }
 

--- a/sifive/devices/uart.h
+++ b/sifive/devices/uart.h
@@ -31,8 +31,8 @@
 
 #ifndef __ASSEMBLER__
 
-/* compat function for debug output, implemented in main.c */
-int puts(const char *s);
+/* compat "function" for debug output */
+#define puts(s) 1 /* nop */
 
 #include <stdint.h>
 /**

--- a/uart/uart.c
+++ b/uart/uart.c
@@ -45,12 +45,6 @@ void uart_put_hex(void* uartctrl, uint32_t hex) {
   int num_nibbles = sizeof(hex) * 2;
   for (int nibble_idx = num_nibbles - 1; nibble_idx >= 0; nibble_idx--) {
     char nibble = (hex >> (nibble_idx * 4)) & 0xf;
-    uart_putc(uartctrl, (nibble < 0xa) ? ('0' + nibble) : ('a' + nibble - 0xa));
+    uart_putc(uartctrl, (nibble < 0xa) ? ('0' + nibble) : ('k' + nibble - 0xa));
   }
 }
-
-void uart_put_hex64(void *uartctrl, uint64_t hex){
-  uart_put_hex(uartctrl,hex>>32);
-  uart_put_hex(uartctrl,hex&0xFFFFFFFF);
-}
-

--- a/ux00_zsbl.lds
+++ b/ux00_zsbl.lds
@@ -33,15 +33,15 @@ SECTIONS
     . += 0x40; /* to create a gap between .text and .data b/c ifetch can fetch ahead from .data */
   } >maskrom_mem  :text
 
-  .eh_frame ALIGN((ADDR(.text) + SIZEOF(.text)), 64) : AT(ALIGN((LOADADDR(.text) + SIZEOF(.text)), 64)) {
+  .eh_frame ALIGN((ADDR(.text) + SIZEOF(.text)), 8) : AT(ALIGN((LOADADDR(.text) + SIZEOF(.text)), 8)) {
     *(.eh_frame)
   } >maskrom_mem  :text
 
-  .rodata ALIGN((ADDR(.eh_frame) + SIZEOF(.eh_frame)), 64) : AT(ALIGN((LOADADDR(.eh_frame) + SIZEOF(.eh_frame)), 64)) ALIGN_WITH_INPUT {
+  .rodata ALIGN((ADDR(.eh_frame) + SIZEOF(.eh_frame)), 8) : AT(ALIGN((LOADADDR(.eh_frame) + SIZEOF(.eh_frame)), 8)) ALIGN_WITH_INPUT {
     *(.rodata .rodata.* .gnu.linkonce.r.*)
   } >maskrom_mem  :rodata
 
-  .srodata ALIGN((ADDR(.rodata) + SIZEOF(.rodata)), 64) : AT(ALIGN((LOADADDR(.rodata) + SIZEOF(.rodata)), 64)) ALIGN_WITH_INPUT {
+  .srodata ALIGN((ADDR(.rodata) + SIZEOF(.rodata)), 8) : AT(ALIGN((LOADADDR(.rodata) + SIZEOF(.rodata)), 8)) ALIGN_WITH_INPUT {
     *(.srodata.cst16)
     *(.srodata.cst8)
     *(.srodata.cst4)
@@ -49,7 +49,7 @@ SECTIONS
     *(.srodata.*)
   } >maskrom_mem  :rodata
 
-  .data ALIGN((ORIGIN(ccache_sideband) + 0x100000), 64) : AT(ALIGN((LOADADDR(.srodata) + SIZEOF(.srodata)), 64)) ALIGN_WITH_INPUT {
+  .data ALIGN((ORIGIN(ccache_sideband) + 0x100000), 8) : AT(ALIGN((LOADADDR(.srodata) + SIZEOF(.srodata)), 8)) ALIGN_WITH_INPUT {
     *(.data .data.* .gnu.linkonce.d.*)
     *(.tohost) /* TODO: Support sections that aren't explicitly listed in this linker script */
   } >ccache_sideband  :data

--- a/ux00boot/ux00boot.c
+++ b/ux00boot/ux00boot.c
@@ -262,8 +262,7 @@ static int decode_sd_copy_error(int error)
   }
 }
 
-
-static int load_sd_gpt_partition(spi_ctrl* spictrl, void* dst, const gpt_guid* partition_type_guid)
+__attribute__((always_inline)) static inline int _load_sd_gpt_partition(spi_ctrl* spictrl, void* dst, const gpt_guid* partition_type_guid)
 {
   uint8_t gpt_buf[GPT_BLOCK_SIZE];
   int error;
@@ -381,7 +380,7 @@ static gpt_partition_range find_mmap_gpt_partition(const void* gpt_base, const g
 /**
  * Load GPT partition from memory-mapped GPT image.
  */
-static int load_mmap_gpt_partition(const void* gpt_base, void* payload_dest, const gpt_guid* partition_type_guid)
+static inline int _load_mmap_gpt_partition(const void* gpt_base, void* payload_dest, const gpt_guid* partition_type_guid)
 {
   gpt_partition_range range = find_mmap_gpt_partition(gpt_base, partition_type_guid);
   if (!gpt_is_valid_partition_range(range)) {
@@ -429,7 +428,7 @@ static gpt_partition_range find_spiflash_gpt_partition(
 /**
  * Load GPT partition from SPI flash.
  */
-static int load_spiflash_gpt_partition(spi_ctrl* spictrl, void* dst, const gpt_guid* partition_type_guid)
+__attribute__((always_inline)) static inline int _load_spiflash_gpt_partition(spi_ctrl* spictrl, void* dst, const gpt_guid* partition_type_guid)
 {
   uint8_t gpt_buf[GPT_BLOCK_SIZE];
   int error;
@@ -464,7 +463,7 @@ static int load_spiflash_gpt_partition(spi_ctrl* spictrl, void* dst, const gpt_g
 }
 
 
-void ux00boot_fail(long code, int trap)
+static inline void _ux00boot_fail(long code, int trap)
 {
   if (read_csr(mhartid) == NONSMP_HART) {
     // Print error code to UART
@@ -513,8 +512,9 @@ void ux00boot_fail(long code, int trap)
  * Read from mode select device to determine which bulk storage medium to read
  * GPT image from, and properly initialize the bulk storage based on type.
  */
-void ux00boot_load_gpt_partition(void* dst, const gpt_guid* partition_type_guid, unsigned int peripheral_input_khz)
+static inline void _ux00boot_load_gpt_partition(void* dst, const gpt_guid* partition_type_guid, unsigned int peripheral_input_khz)
 {
+#if 0
   uint32_t mode_select = *((volatile uint32_t*) MODESELECT_MEM_ADDR);
 
   spi_ctrl* spictrl = NULL;
@@ -573,4 +573,283 @@ void ux00boot_load_gpt_partition(void* dst, const gpt_guid* partition_type_guid,
   if (error) {
     ux00boot_fail(error, 0);
   }
+#else
+  /* From @esmil */
+  static const uint8_t data1[40] __attribute__((section(".rodata.1"))) = {
+    0x52,0xd8,0xff,0xff, 0x52,0xd8,0xff,0xff, 0x56,0xd8,0xff,0xff, 0xbe,0xd8,0xff,0xff,
+    0x52,0xd8,0xff,0xff, 0x56,0xd8,0xff,0xff, 0xbe,0xd8,0xff,0xff, 0x52,0xd8,0xff,0xff,
+    0xbe,0xd8,0xff,0xff, 0x52,0xd8,0xff,0xff,
+  };
+  static const uint8_t data2[40] __attribute__((section(".rodata.2"))) = {
+    0x6e,0xd7,0xff,0xff, 0x6e,0xd7,0xff,0xff,
+    0xc2,0xd7,0xff,0xff, 0x9c,0xd8,0xff,0xff, 0x6e,0xd7,0xff,0xff, 0xc2,0xd7,0xff,0xff,
+    0x9c,0xd8,0xff,0xff, 0x6e,0xd7,0xff,0xff, 0x9c,0xd8,0xff,0xff, 0x6e,0xd7,0xff,0xff,
+  };
+  static const uint8_t data3[40] __attribute__((section(".rodata.3"))) = {
+    0xea,0xd7,0xff,0xff, 0xea,0xd7,0xff,0xff, 0xf2,0xd7,0xff,0xff, 0x1e,0xd8,0xff,0xff,
+    0xea,0xd7,0xff,0xff, 0xf2,0xd7,0xff,0xff, 0x1e,0xd8,0xff,0xff, 0xea,0xd7,0xff,0xff,
+    0x1e,0xd8,0xff,0xff, 0xea,0xd7,0xff,0xff,
+  };
+  static const uint8_t data4[24] __attribute__((section(".rodata.4"))) = {
+    0x05,0x00,0x00,0x00, 0x06,0x00,0x00,0x00,
+    0x07,0x00,0x00,0x00, 0x08,0x00,0x00,0x00, 0x09,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
+  };
+
+  __asm__ __volatile__ (
+    /* 10600: */ "lui     a5,0x1\n"
+    /* 10602: */ "lw      a5,0(a5)\n"
+    /* 10604: */ "addi    sp,sp,-48\n"
+    /* 10606: */ "sd      ra,40(sp)\n"
+    /* 10608: */ "sext.w  a5,a5\n"
+    /* 1060a: */ "sd      s0,32(sp)\n"
+    /* 1060c: */ "sd      s1,24(sp)\n"
+    /* 1060e: */ "sd      s2,16(sp)\n"
+    /* 10610: */ "sd      s3,8(sp)\n"
+    /* 10612: */ "li      a4,10\n"
+    /* 10614: */ "addiw   a3,a5,-5\n"
+    /* 10618: */ "bleu    a3,a4,2f\n" /* 10628 <ux00boot_load_gpt_partition+0x28> */
+                 "1:\n"
+    /* 1061c: */ "li      a1,0\n"
+    /* 1061e: */ "li      a0,1\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 10620: */ "call    ux00boot_fail\n"
+                 ".option pop\n"
+                 "2:\n"
+    /* 10628: */ "li      a4,1\n"
+    /* 1062a: */ "sll     a4,a4,a3\n"
+    /* 1062e: */ "andi    a3,a4,1571\n"
+    /* 10632: */ "mv      s1,a1\n"
+    /* 10634: */ "mv      s0,a0\n"
+    /* 10636: */ "mv      a1,a2\n"
+    /* 10638: */ "bnez    a3,3f\n" /* 10668 <ux00boot_load_gpt_partition+0x68> */
+    /* 1063a: */ "andi    a3,a4,80\n"
+    /* 1063e: */ "bnez    a3,4f\n" /* 1068a <ux00boot_load_gpt_partition+0x8a> */
+    /* 10640: */ "andi    a4,a4,396\n"
+    /* 10644: */ "beqz    a4,1b\n" /* 1061c <ux00boot_load_gpt_partition+0x1c> */
+    /* 10646: */ "addiw   a5,a5,-6\n"
+    /* 10648: */ "sext.w  a3,a5\n"
+    /* 1064c: */ "li      a4,9\n"
+    /* 1064e: */ "bltu    a4,a3,19f\n" /* 107e0 <ux00boot_load_gpt_partition+0x1e0> */
+    /* 10652: */ "slli    a5,a5,0x20\n"
+    /* 10654: */ "srli    a5,a5,0x20\n"
+    /* 10656: */ "la      a4,%0\n"
+    /* 1065e: */ "slli    a5,a5,0x2\n"
+    /* 10660: */ "add     a5,a5,a4\n"
+    /* 10662: */ "lw      a5,0(a5)\n"
+    /* 10664: */ "add     a5,a5,a4\n"
+    /* 10666: */ "jr      a5\n"
+                 "3:\n"
+    /* 10668: */ "addiw   a5,a5,-6\n"
+    /* 1066a: */ "sext.w  a3,a5\n"
+    /* 1066e: */ "li      a4,9\n"
+    /* 10670: */ "bltu    a4,a3,5f\n" /* 106ac <ux00boot_load_gpt_partition+0xac> */
+    /* 10674: */ "slli    a5,a5,0x20\n"
+    /* 10676: */ "srli    a5,a5,0x20\n"
+    /* 10678: */ "la      a4,%1\n"
+    /* 10680: */ "slli    a5,a5,0x2\n"
+    /* 10682: */ "add     a5,a5,a4\n"
+    /* 10684: */ "lw      a5,0(a5)\n"
+    /* 10686: */ "add     a5,a5,a4\n"
+    /* 10688: */ "jr      a5\n"
+                 "4:\n"
+    /* 1068a: */ "addiw   a5,a5,-6\n"
+    /* 1068c: */ "sext.w  a3,a5\n"
+    /* 10690: */ "li      a4,9\n"
+    /* 10692: */ "bltu    a4,a3,20f\n" /* 107f4 <ux00boot_load_gpt_partition+0x1f4> */
+    /* 10696: */ "slli    a5,a5,0x20\n"
+    /* 10698: */ "srli    a5,a5,0x20\n"
+    /* 1069a: */ "la      a4,%2\n"
+    /* 106a2: */ "slli    a5,a5,0x2\n"
+    /* 106a4: */ "add     a5,a5,a4\n"
+    /* 106a6: */ "lw      a5,0(a5)\n"
+    /* 106a8: */ "add     a5,a5,a4\n"
+    /* 106aa: */ "jr      a5\n"
+                 "5:\n"
+    /* 106ac: */ "lui     s3,0x20000\n"
+    /* 106b0: */ "lui     s2,0x10040\n"
+                 "6:\n"
+    /* 106b4: */ "lui     a4,0x5\n"
+    /* 106b6: */ "addiw   a5,a4,-481\n"
+    /* 106ba: */ "addw    a1,a1,a5\n"
+    /* 106bc: */ "addiw   a4,a4,-480\n"
+    /* 106c0: */ "divuw   a5,a1,a4\n"
+    /* 106c4: */ "beqz    a5,7f\n" /* 106c8 <ux00boot_load_gpt_partition+0xc8> */
+    /* 106c6: */ "addiw   a5,a5,-1\n"
+                 "7:\n"
+    /* 106c8: */ "sw      a5,0(s2) # 10040000 <_sp+0x7e60000>\n"
+    /* 106cc: */ "lw      a5,96(s2)\n"
+    /* 106d0: */ "li      a1,102\n"
+    /* 106d4: */ "mv      a0,s2\n"
+    /* 106d6: */ "andi    a5,a5,-2\n"
+    /* 106d8: */ "sw      a5,96(s2)\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 106dc: */ "call    spi_txrx\n"
+                 ".option pop\n"
+    /* 106e4: */ "li      a1,153\n"
+    /* 106e8: */ "mv      a0,s2\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 106ea: */ "call    spi_txrx\n"
+                 ".option pop\n"
+    /* 106f2: */ "lui     a5,0x30\n"
+    /* 106f6: */ "ori     a5,a5,7\n"
+                 "8:\n"
+    /* 106fa: */ "sw      a5,100(s2)\n"
+    /* 106fe: */ "lw      a5,96(s2)\n"
+    /* 10702: */ "ori     a5,a5,1\n"
+    /* 10706: */ "sw      a5,96(s2)\n"
+    /* 1070a: */ "fence   io,io\n"
+    /* 1070e: */ "mv      a2,s1\n"
+    /* 10710: */ "mv      a1,s0\n"
+    /* 10712: */ "mv      a0,s3\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 10714: */ "call    load_mmap_gpt_partition\n"
+                 ".option pop\n"
+    /* 1071c: */ "sext.w  a0,a0\n"
+                 "9:\n"
+    /* 1071e: */ "bnez    a0,16f\n" /* 107c0 <ux00boot_load_gpt_partition+0x1c0> */
+    /* 10720: */ "ld      ra,40(sp)\n"
+    /* 10722: */ "ld      s0,32(sp)\n"
+    /* 10724: */ "ld      s1,24(sp)\n"
+    /* 10726: */ "ld      s2,16(sp)\n"
+    /* 10728: */ "ld      s3,8(sp)\n"
+    /* 1072a: */ "addi    sp,sp,48\n"
+    /* 1072c: */ "ret\n"
+    /* 1072e: */ "li      a5,0\n"
+                 "10:\n"
+    /* 10730: */ "bnez    a5,21f\n" /* 107fc <ux00boot_load_gpt_partition+0x1fc> */
+    /* 10732: */ "lui     s3,0x20000\n"
+    /* 10736: */ "lui     s2,0x10040\n"
+                 "11:\n"
+    /* 1073a: */ "lui     a4,0x5\n"
+    /* 1073c: */ "addiw   a5,a4,-481\n"
+    /* 10740: */ "addw    a1,a1,a5\n"
+    /* 10742: */ "addiw   a4,a4,-480\n"
+    /* 10746: */ "divuw   a5,a1,a4\n"
+    /* 1074a: */ "beqz    a5,12f\n" /* 1074e <ux00boot_load_gpt_partition+0x14e> */
+    /* 1074c: */ "addiw   a5,a5,-1\n"
+                 "12:\n"
+    /* 1074e: */ "sw      a5,0(s2) # 10040000 <_sp+0x7e60000>\n"
+    /* 10752: */ "lw      a5,96(s2)\n"
+    /* 10756: */ "li      a1,102\n"
+    /* 1075a: */ "mv      a0,s2\n"
+    /* 1075c: */ "andi    a5,a5,-2\n"
+    /* 1075e: */ "sw      a5,96(s2)\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 10762: */ "call    spi_txrx\n"
+                 ".option pop\n"
+    /* 1076a: */ "li      a1,153\n"
+    /* 1076e: */ "mv      a0,s2\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 10770: */ "call    spi_txrx\n"
+                 ".option pop\n"
+    /* 10778: */ "lui     a5,0x6b2\n"
+    /* 1077c: */ "addi    a5,a5,135 # 6b2087 <_data_lma+0x69f01f>\n"
+    /* 10780: */ "j       8b\n" /* 106fa <ux00boot_load_gpt_partition+0xfa> */
+    /* 10782: */ "lui     s2,0x10040\n"
+                 "13:\n"
+    /* 10786: */ "li      a2,0\n"
+    /* 10788: */ "mv      a0,s2\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 1078a: */ "call    sd_init\n"
+                 ".option pop\n"
+    /* 10792: */ "bnez    a0,15f\n" /* 107a2 <ux00boot_load_gpt_partition+0x1a2> */
+                 "14:\n"
+    /* 10794: */ "mv      a2,s1\n"
+    /* 10796: */ "mv      a1,s0\n"
+    /* 10798: */ "mv      a0,s2\n"
+    /* 1079a: */ "call    load_sd_gpt_partition\n"
+    /* 1079e: */ "sext.w  a0,a0\n"
+    /* 107a0: */ "j       9b\n" /* 1071e <ux00boot_load_gpt_partition+0x11e> */
+                 "15:\n"
+    /* 107a2: */ "addiw   a0,a0,-1\n"
+    /* 107a4: */ "sext.w  a4,a0\n"
+    /* 107a8: */ "li      a5,4\n"
+    /* 107aa: */ "bltu    a5,a4,18f\n" /* 107ce <ux00boot_load_gpt_partition+0x1ce> */
+    /* 107ae: */ "slli    a0,a0,0x20\n"
+    /* 107b0: */ "srli    a0,a0,0x1e\n"
+    /* 107b2: */ "la      a5,%3\n"
+    /* 107ba: */ "add     a0,a0,a5\n"
+    /* 107bc: */ "lw      a0,0(a0)\n"
+    /* 107be: */ "beqz    a0,14b\n" /* 10794 <ux00boot_load_gpt_partition+0x194> */
+                 "16:\n"
+    /* 107c0: */ "slli    a0,a0,0x20\n"
+    /* 107c2: */ "srli    a0,a0,0x20\n"
+                 "17:\n"
+    /* 107c4: */ "li      a1,0\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 107c6: */ "call    ux00boot_fail\n"
+                 ".option pop\n"
+                 "18:\n"
+    /* 107ce: */ "li      a0,12\n"
+    /* 107d0: */ "j       17b\n" /* 107c4 <ux00boot_load_gpt_partition+0x1c4> */
+    /* 107d2: */ "li      s3,0\n"
+    /* 107d4: */ "lui     s2,0x10050\n"
+    /* 107d8: */ "j       11b\n" /* 1073a <ux00boot_load_gpt_partition+0x13a> */
+    /* 107da: */ "lui     s2,0x10050\n"
+    /* 107de: */ "j       13b\n" /* 10786 <ux00boot_load_gpt_partition+0x186> */
+                 "19:\n"
+    /* 107e0: */ "lui     s3,0x30000\n"
+    /* 107e4: */ "lui     s2,0x10041\n"
+    /* 107e8: */ "j       6b\n" /* 106b4 <ux00boot_load_gpt_partition+0xb4> */
+    /* 107ea: */ "li      a5,1\n"
+    /* 107ec: */ "j       10b\n" /* 10730 <ux00boot_load_gpt_partition+0x130> */
+    /* 107ee: */ "lui     s2,0x10041\n"
+    /* 107f2: */ "j       13b\n" /* 10786 <ux00boot_load_gpt_partition+0x186> */
+                 "20:\n"
+    /* 107f4: */ "li      s3,0\n"
+    /* 107f6: */ "lui     s2,0x10050\n"
+    /* 107fa: */ "j       6b\n" /* 106b4 <ux00boot_load_gpt_partition+0xb4> */
+                 "21:\n"
+    /* 107fc: */ "lui     s3,0x30000\n"
+    /* 10800: */ "lui     s2,0x10041\n"
+    /* 10804: */ "j       11b\n" /* 1073a <ux00boot_load_gpt_partition+0x13a> */
+    /* 10806: */ "lui     s2,0x10050\n"
+                 "22:\n"
+    /* 1080a: */ "lui     a4,0x5\n"
+    /* 1080c: */ "addiw   a5,a4,-481\n"
+    /* 10810: */ "addw    a1,a1,a5\n"
+    /* 10812: */ "addiw   a4,a4,-480\n"
+    /* 10816: */ "divuw   a5,a1,a4\n"
+    /* 1081a: */ "beqz    a5,23f\n" /* 1081e <ux00boot_load_gpt_partition+0x21e> */
+    /* 1081c: */ "addiw   a5,a5,-1\n"
+                 "23:\n"
+    /* 1081e: */ "sw      a5,0(s2) # 10050000 <_sp+0x7e70000>\n"
+    /* 10822: */ "lw      a5,96(s2)\n"
+    /* 10826: */ "li      a1,102\n"
+    /* 1082a: */ "mv      a0,s2\n"
+    /* 1082c: */ "andi    a5,a5,-2\n"
+    /* 1082e: */ "sw      a5,96(s2)\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 10832: */ "call    spi_txrx\n"
+                 ".option pop\n"
+    /* 1083a: */ "li      a1,153\n"
+    /* 1083e: */ "mv      a0,s2\n"
+                 ".option push\n"
+                 ".option norelax\n"
+    /* 10840: */ "call    spi_txrx\n"
+                 ".option pop\n"
+    /* 10848: */ "mv      a2,s1\n"
+    /* 1084a: */ "mv      a1,s0\n"
+    /* 1084c: */ "mv      a0,s2\n"
+    /* 1084e: */ "call    load_spiflash_gpt_partition\n"
+    /* 10852: */ "sext.w  a0,a0\n"
+    /* 10854: */ "j       9b\n" /* 1071e <ux00boot_load_gpt_partition+0x11e> */
+    /* 10856: */ "lui     s2,0x10041\n"
+    /* 1085a: */ "j       22b\n" /* 1080a <ux00boot_load_gpt_partition+0x20a> */
+    /* 1085c: */ "lui     s2,0x10040\n"
+    /* 10860: */ "j       22b\n" /* 1080a <ux00boot_load_gpt_partition+0x20a> */
+    :
+    : "i" (data1), "i" (data2), "i" (data3), "i" (data4)
+  );
+  __builtin_unreachable();
+#endif
 }

--- a/zsbl/main.c
+++ b/zsbl/main.c
@@ -30,11 +30,6 @@ void init_uart(unsigned int peripheral_input_khz)
   UART0_REG(UART_REG_DIV) = uart_min_clk_divisor(peripheral_input_khz * 1000ULL, uart_target_hz);
 }
 
-/* no-op */
-int puts(const char* str){
-	return 1;
-}
-
 int main()
 {
   if (read_csr(mhartid) == NONSMP_HART) {

--- a/zsbl/main.o.patch
+++ b/zsbl/main.o.patch
@@ -1,0 +1,50 @@
+--- zsbl/main.o.s	2018-09-13 14:59:25.152816720 -0600
++++ zsbl/main.o.s.2	2018-09-13 15:19:52.013338362 -0600
+@@ -153,26 +153,26 @@
+ .LBB34:
+ 	.file 3 "./sifive/barrier.h"
+ 	.loc 3 27 0
+-	.LA2: auipc	a5,%pcrel_hi(.LANCHOR0)
+-	addi	a5,a5,%pcrel_lo(.LA2)
++	.LA2: auipc	a2,%pcrel_hi(.LANCHOR0)
++	addi	a2,a2,%pcrel_lo(.LA2)
+ 	fence	iorw,iorw
+-	lw	a2,16(a5)
++	lw	a5,16(a2)
+ 	.loc 3 29 0
+ 	li	a0,1
+ 	.loc 3 27 0
+ 	fence	iorw,iorw
+-	sext.w	a2,a2
++	sext.w	a5,a5
+ .LVL11:
+-	sll	a4,a2,2
++	sll	a4,a5,2
+ 	.loc 3 29 0
+-	add	a3,a5,a4
++	add	a3,a2,a4
+ 	fence iorw,ow; amoadd.w.aq a1,a0,0(a3)
+ 	add	a4,a4,8
+ 	sext.w	a1,a1
+ .LVL12:
+ 	.loc 3 32 0
+ 	li	a6,4
+-	add	a4,a5,a4
++	add	a4,a2,a4
+ 	beq	a1,a6,.L19
+ .L10:
+ 	.loc 3 41 0
+@@ -218,10 +218,10 @@
+ .LVL16:
+ .L19:
+ 	.loc 3 34 0
+-	subw	a2,a0,a2
++	subw	a5,a0,a5
+ .LVL17:
+-	add	a5,a5,16
+-	fence iorw,ow; amoswap.w.aq zero,a2,0(a5)
++	add	a2,a2,16
++	fence iorw,ow; amoswap.w.aq zero,a5,0(a2)
+ 	.loc 3 36 0
+ 	li	a5,-1
+ 	fence iorw,ow; amoadd.w.aq zero,a5,0(a3)

--- a/zsbl/ux00_zsbl.dts
+++ b/zsbl/ux00_zsbl.dts
@@ -3,418 +3,464 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
 
+/* From @SirCmpwn */
+
 /dts-v1/;
 
 / {
-	#address-cells = <2>;
-	#size-cells = <2>;
-	compatible = "freechips,rocketchip-unknown-dev";
-	model = "freechips,rocketchip-unknown";
-	L56: cpus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		L9: cpu@0 {
-			clock-frequency = <0>;
-			compatible = "sifive,rocket0", "riscv";
+	#address-cells = < 0x02 >;
+	#size-cells = < 0x02 >;
+	compatible = "SiFive,FU540G-dev\0fu500-dev\0sifive-dev";
+	model = "SiFive,FU540G";
+
+	cpus {
+		#address-cells = < 0x01 >;
+		#size-cells = < 0x00 >;
+		timebase-frequency = < 0xf4240 >;
+
+		cpu@0 {
+			clock-frequency = < 0x00 >;
+			compatible = "sifive,rocket0\0riscv";
 			device_type = "cpu";
-			i-cache-block-size = <64>;
-			i-cache-sets = <128>;
-			i-cache-size = <16384>;
-			next-level-cache = <&L0 &L27>;
-			reg = <0>;
+			i-cache-block-size = < 0x40 >;
+			i-cache-sets = < 0x80 >;
+			i-cache-size = < 0x4000 >;
+			next-level-cache = < 0x01 0x02 >;
+			reg = < 0x00 >;
 			riscv,isa = "rv64imac";
-			sifive,dtim = <&L7>;
-			sifive,itim = <&L6>;
+			sifive,dtim = < 0x03 >;
+			sifive,itim = < 0x04 >;
 			status = "okay";
-			timebase-frequency = <1000000>;
-			L5: interrupt-controller {
-				#interrupt-cells = <1>;
+
+			interrupt-controller {
+				#interrupt-cells = < 0x01 >;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				linux,phandle = < 0x0d >;
+				phandle = < 0x0d >;
 			};
 		};
-		L13: cpu@1 {
-			clock-frequency = <0>;
-			compatible = "sifive,rocket0", "riscv";
-			d-cache-block-size = <64>;
-			d-cache-sets = <64>;
-			d-cache-size = <32768>;
-			d-tlb-sets = <1>;
-			d-tlb-size = <32>;
+
+		cpu@1 {
+			clock-frequency = < 0x00 >;
+			compatible = "sifive,rocket0\0riscv";
+			d-cache-block-size = < 0x40 >;
+			d-cache-sets = < 0x40 >;
+			d-cache-size = < 0x8000 >;
+			d-tlb-sets = < 0x01 >;
+			d-tlb-size = < 0x20 >;
 			device_type = "cpu";
-			i-cache-block-size = <64>;
-			i-cache-sets = <64>;
-			i-cache-size = <32768>;
-			i-tlb-sets = <1>;
-			i-tlb-size = <32>;
+			i-cache-block-size = < 0x40 >;
+			i-cache-sets = < 0x40 >;
+			i-cache-size = < 0x8000 >;
+			i-tlb-sets = < 0x01 >;
+			i-tlb-size = < 0x20 >;
 			mmu-type = "riscv,sv39";
-			next-level-cache = <&L0 &L27>;
-			reg = <1>;
+			next-level-cache = < 0x01 0x02 >;
+			reg = < 0x01 >;
 			riscv,isa = "rv64imafdc";
-			sifive,itim = <&L11>;
+			sifive,itim = < 0x05 >;
 			status = "okay";
-			timebase-frequency = <1000000>;
 			tlb-split;
-			L10: interrupt-controller {
-				#interrupt-cells = <1>;
+
+			interrupt-controller {
+				#interrupt-cells = < 0x01 >;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				linux,phandle = < 0x0e >;
+				phandle = < 0x0e >;
 			};
 		};
-		L17: cpu@2 {
-			clock-frequency = <0>;
-			compatible = "sifive,rocket0", "riscv";
-			d-cache-block-size = <64>;
-			d-cache-sets = <64>;
-			d-cache-size = <32768>;
-			d-tlb-sets = <1>;
-			d-tlb-size = <32>;
+
+		cpu@2 {
+			clock-frequency = < 0x00 >;
+			compatible = "sifive,rocket0\0riscv";
+			d-cache-block-size = < 0x40 >;
+			d-cache-sets = < 0x40 >;
+			d-cache-size = < 0x8000 >;
+			d-tlb-sets = < 0x01 >;
+			d-tlb-size = < 0x20 >;
 			device_type = "cpu";
-			i-cache-block-size = <64>;
-			i-cache-sets = <64>;
-			i-cache-size = <32768>;
-			i-tlb-sets = <1>;
-			i-tlb-size = <32>;
+			i-cache-block-size = < 0x40 >;
+			i-cache-sets = < 0x40 >;
+			i-cache-size = < 0x8000 >;
+			i-tlb-sets = < 0x01 >;
+			i-tlb-size = < 0x20 >;
 			mmu-type = "riscv,sv39";
-			next-level-cache = <&L0 &L27>;
-			reg = <2>;
+			next-level-cache = < 0x01 0x02 >;
+			reg = < 0x02 >;
 			riscv,isa = "rv64imafdc";
-			sifive,itim = <&L15>;
+			sifive,itim = < 0x06 >;
 			status = "okay";
-			timebase-frequency = <1000000>;
 			tlb-split;
-			L14: interrupt-controller {
-				#interrupt-cells = <1>;
+
+			interrupt-controller {
+				#interrupt-cells = < 0x01 >;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				linux,phandle = < 0x0f >;
+				phandle = < 0x0f >;
 			};
 		};
-		L21: cpu@3 {
-			clock-frequency = <0>;
-			compatible = "sifive,rocket0", "riscv";
-			d-cache-block-size = <64>;
-			d-cache-sets = <64>;
-			d-cache-size = <32768>;
-			d-tlb-sets = <1>;
-			d-tlb-size = <32>;
+
+		cpu@3 {
+			clock-frequency = < 0x00 >;
+			compatible = "sifive,rocket0\0riscv";
+			d-cache-block-size = < 0x40 >;
+			d-cache-sets = < 0x40 >;
+			d-cache-size = < 0x8000 >;
+			d-tlb-sets = < 0x01 >;
+			d-tlb-size = < 0x20 >;
 			device_type = "cpu";
-			i-cache-block-size = <64>;
-			i-cache-sets = <64>;
-			i-cache-size = <32768>;
-			i-tlb-sets = <1>;
-			i-tlb-size = <32>;
+			i-cache-block-size = < 0x40 >;
+			i-cache-sets = < 0x40 >;
+			i-cache-size = < 0x8000 >;
+			i-tlb-sets = < 0x01 >;
+			i-tlb-size = < 0x20 >;
 			mmu-type = "riscv,sv39";
-			next-level-cache = <&L0 &L27>;
-			reg = <3>;
+			next-level-cache = < 0x01 0x02 >;
+			reg = < 0x03 >;
 			riscv,isa = "rv64imafdc";
-			sifive,itim = <&L19>;
+			sifive,itim = < 0x07 >;
 			status = "okay";
-			timebase-frequency = <1000000>;
 			tlb-split;
-			L18: interrupt-controller {
-				#interrupt-cells = <1>;
+
+			interrupt-controller {
+				#interrupt-cells = < 0x01 >;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				linux,phandle = < 0x10 >;
+				phandle = < 0x10 >;
 			};
 		};
-		L25: cpu@4 {
-			clock-frequency = <0>;
-			compatible = "sifive,rocket0", "riscv";
-			d-cache-block-size = <64>;
-			d-cache-sets = <64>;
-			d-cache-size = <32768>;
-			d-tlb-sets = <1>;
-			d-tlb-size = <32>;
+
+		cpu@4 {
+			clock-frequency = < 0x00 >;
+			compatible = "sifive,rocket0\0riscv";
+			d-cache-block-size = < 0x40 >;
+			d-cache-sets = < 0x40 >;
+			d-cache-size = < 0x8000 >;
+			d-tlb-sets = < 0x01 >;
+			d-tlb-size = < 0x20 >;
 			device_type = "cpu";
-			i-cache-block-size = <64>;
-			i-cache-sets = <64>;
-			i-cache-size = <32768>;
-			i-tlb-sets = <1>;
-			i-tlb-size = <32>;
+			i-cache-block-size = < 0x40 >;
+			i-cache-sets = < 0x40 >;
+			i-cache-size = < 0x8000 >;
+			i-tlb-sets = < 0x01 >;
+			i-tlb-size = < 0x20 >;
 			mmu-type = "riscv,sv39";
-			next-level-cache = <&L0 &L27>;
-			reg = <4>;
+			next-level-cache = < 0x01 0x02 >;
+			reg = < 0x04 >;
 			riscv,isa = "rv64imafdc";
-			sifive,itim = <&L23>;
+			sifive,itim = < 0x08 >;
 			status = "okay";
-			timebase-frequency = <1000000>;
 			tlb-split;
-			L22: interrupt-controller {
-				#interrupt-cells = <1>;
+
+			interrupt-controller {
+				#interrupt-cells = < 0x01 >;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				linux,phandle = < 0x11 >;
+				phandle = < 0x11 >;
 			};
 		};
 	};
-	L37: memory@80000000 {
+
+	memory@80000000 {
 		device_type = "memory";
-		reg = <0x0 0x80000000 0x1f 0x80000000>;
+		reg = < 0x00 0x80000000 0x1f 0x80000000 >;
+		linux,phandle = < 0x0c >;
+		phandle = < 0x0c >;
 	};
-	L55: soc {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		compatible = "freechips,rocketchip-unknown-soc", "simple-bus";
+
+	soc {
+		#address-cells = < 0x02 >;
+		#size-cells = < 0x02 >;
+		compatible = "SiFive,FU540G-soc\0fu500-soc\0sifive-soc\0simple-bus";
 		ranges;
-		L8: bus-error-unit@1700000 {
-			compatible = "sifive,buserror0";
-			interrupt-parent = <&L2>;
-			interrupts = <55>;
-			reg = <0x0 0x1700000 0x0 0x1000>;
+
+		bus-blocker@100b8000 {
+			compatible = "sifive,bus-blocker0";
+			reg = < 0x00 0x100b8000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L12: bus-error-unit@1701000 {
-			compatible = "sifive,buserror0";
-			interrupt-parent = <&L2>;
-			interrupts = <56>;
-			reg = <0x0 0x1701000 0x0 0x1000>;
-			reg-names = "control";
-		};
-		L16: bus-error-unit@1702000 {
-			compatible = "sifive,buserror0";
-			interrupt-parent = <&L2>;
-			interrupts = <57>;
-			reg = <0x0 0x1702000 0x0 0x1000>;
-			reg-names = "control";
-		};
-		L20: bus-error-unit@1703000 {
-			compatible = "sifive,buserror0";
-			interrupt-parent = <&L2>;
-			interrupts = <58>;
-			reg = <0x0 0x1703000 0x0 0x1000>;
-			reg-names = "control";
-		};
-		L24: bus-error-unit@1704000 {
-			compatible = "sifive,buserror0";
-			interrupt-parent = <&L2>;
-			interrupts = <59>;
-			reg = <0x0 0x1704000 0x0 0x1000>;
-			reg-names = "control";
-		};
-		L0: cache-controller@2010000 {
-			cache-block-size = <64>;
-			cache-level = <2>;
-			cache-sets = <2048>;
-			cache-size = <2097152>;
+
+		cache-controller@2010000 {
+			cache-block-size = < 0x40 >;
+			cache-level = < 0x02 >;
+			cache-sets = < 0x800 >;
+			cache-size = < 0x200000 >;
 			cache-unified;
-			compatible = "sifive,ccache0", "cache";
-			interrupt-parent = <&L2>;
-			interrupts = <1 2 3 4>;
-			next-level-cache = <&L29 &L37 &L40>;
-			reg = <0x0 0x2010000 0x0 0x1000 0x0 0x8000000 0x0 0x200000>;
-			reg-names = "control", "sideband";
+			compatible = "sifive,ccache0\0cache";
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x01 0x02 0x03 >;
+			next-level-cache = < 0x0a 0x0b 0x0c >;
+			reg = < 0x00 0x2010000 0x00 0x1000 0x00 0x8000000 0x00 0x2000000 >;
+			reg-names = "control\0sideband";
+			linux,phandle = < 0x02 >;
+			phandle = < 0x02 >;
 		};
-		L39: cadence-ddr-mgmt@100c0000 {
+
+		cadence-ddr-mgmt@100c0000 {
 			compatible = "sifive,cadenceddrmgmt0";
-			reg = <0x0 0x100c0000 0x0 0x1000>;
+			reg = < 0x00 0x100c0000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L51: cadence-gemgxl-mgmt@100a0000 {
+
+		cadence-gemgxl-mgmt@100a0000 {
 			compatible = "sifive,cadencegemgxlmgmt0";
-			reg = <0x0 0x100a0000 0x0 0x1000>;
+			reg = < 0x00 0x100a0000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L40: chiplink@40000000 {
-			#address-cells = <2>;
-			#size-cells = <2>;
-			compatible = "sifive,chiplink", "simple-bus";
-			ranges = <0x0 0x40000000 0x0 0x40000000 0x0 0x20000000 0x20 0x0 0x20 0x0 0x10 0x0 0x0 0x60000000 0x0 0x60000000 0x0 0x20000000 0x30 0x0 0x30 0x0 0x10 0x0>;
+
+		chiplink@40000000 {
+			#address-cells = < 0x02 >;
+			#size-cells = < 0x02 >;
+			compatible = "sifive,chiplink\0simple-bus";
+			ranges = < 0x00 0x60000000 0x00 0x60000000 0x00 0x20000000 0x30 0x00 0x30 0x00 0x10 0x00 0x00 0x40000000 0x00 0x40000000 0x00 0x20000000 0x20 0x00 0x20 0x00 0x10 0x00 >;
+			linux,phandle = < 0x0b >;
+			phandle = < 0x0b >;
 		};
-		L3: clint@2000000 {
+
+		clint@2000000 {
 			compatible = "riscv,clint0";
-			interrupts-extended = <&L5 3 &L5 7 &L10 3 &L10 7 &L14 3 &L14 7 &L18 3 &L18 7 &L22 3 &L22 7>;
-			reg = <0x0 0x2000000 0x0 0x10000>;
+			interrupts-extended = < 0x0d 0x03 0x0d 0x07 0x0e 0x03 0x0e 0x07 0x0f 0x03 0x0f 0x07 0x10 0x03 0x10 0x07 0x11 0x03 0x11 0x07 >;
+			reg = < 0x00 0x2000000 0x00 0x10000 >;
 			reg-names = "control";
 		};
-		L4: debug-controller@0 {
-			compatible = "sifive,debug-013", "riscv,debug-013";
-			interrupts-extended = <&L5 65535 &L10 65535 &L14 65535 &L18 65535 &L22 65535>;
-			reg = <0x0 0x0 0x0 0x1000>;
+
+		debug-controller@0 {
+			compatible = "sifive,debug-013\0riscv,debug-013";
+			interrupts-extended = < 0x0d 0xffff 0x0e 0xffff 0x0f 0xffff 0x10 0xffff 0x11 0xffff >;
+			reg = < 0x00 0x00 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L36: dma@3000000 {
-			#dma-cells = <1>;
+
+		dma@3000000 {
+			#dma-cells = < 0x01 >;
 			compatible = "riscv,dma0";
-			dma-channels = <4>;
-			dma-requests = <0>;
-			interrupt-parent = <&L2>;
-			interrupts = <24 25 26 27 28 29 30 31>;
-			reg = <0x0 0x3000000 0x0 0x100000>;
+			dma-channels = < 0x04 >;
+			dma-requests = < 0x00 >;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e >;
+			reg = < 0x00 0x3000000 0x00 0x100000 >;
 			reg-names = "control";
-			riscv,dma-pools = <1>;
+			riscv,dma-pools = < 0x01 >;
 		};
-		L7: dtim@1000000 {
+
+		dtim@1000000 {
 			compatible = "sifive,dtim0";
-			reg = <0x0 0x1000000 0x0 0x2000>;
+			reg = < 0x00 0x1000000 0x00 0x2000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x03 >;
+			phandle = < 0x03 >;
 		};
-		L44: ememoryotp@10070000 {
+
+		ememoryotp@10070000 {
 			compatible = "sifive,ememoryotp0";
-			reg = <0x0 0x10070000 0x0 0x1000>;
+			reg = < 0x00 0x10070000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L27: error-device@18000000 {
+
+		error-device@18000000 {
 			compatible = "sifive,error0";
-			reg = <0x0 0x18000000 0x0 0x8000000>;
+			reg = < 0x00 0x18000000 0x00 0x8000000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x01 >;
+			phandle = < 0x01 >;
 		};
-		L52: ethernet@10090000 {
+
+		ethernet@10090000 {
 			compatible = "cdns,mac";
-			interrupt-parent = <&L2>;
-			interrupts = <54>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x35 >;
 			mac-address = "ABCDE";
-			reg = <0x0 0x10090000 0x0 0x2000>;
+			reg = < 0x00 0x10090000 0x00 0x2000 >;
 			reg-names = "control";
 		};
-		L35: gpio@10060000 {
+
+		gpio@10060000 {
 			compatible = "sifive,gpio0";
-			interrupt-parent = <&L2>;
-			interrupts = <8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23>;
-			reg = <0x0 0x10060000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x07 0x08 0x09 0x0a 0x0b 0x0c 0x0d 0x0e 0x0f 0x10 0x11 0x12 0x13 0x14 0x15 0x16 >;
+			reg = < 0x00 0x10060000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L47: i2c@10030000 {
+
+		i2c@10030000 {
 			compatible = "sifive,i2c0";
-			interrupt-parent = <&L2>;
-			interrupts = <51>;
-			reg = <0x0 0x10030000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x32 >;
+			reg = < 0x00 0x10030000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L2: interrupt-controller@c000000 {
-			#interrupt-cells = <1>;
+
+		interrupt-controller@c000000 {
+			#interrupt-cells = < 0x01 >;
 			compatible = "riscv,plic0";
 			interrupt-controller;
-			interrupts-extended = <&L5 11 &L10 11 &L10 9 &L14 11 &L14 9 &L18 11 &L18 9 &L22 11 &L22 9>;
-			reg = <0x0 0xc000000 0x0 0x4000000>;
+			interrupts-extended = < 0x0d 0x0b 0x0e 0x0b 0x0e 0x09 0x0f 0x0b 0x0f 0x09 0x10 0x0b 0x10 0x09 0x11 0x0b 0x11 0x09 >;
+			reg = < 0x00 0xc000000 0x00 0x4000000 >;
 			reg-names = "control";
-			riscv,max-priority = <7>;
-			riscv,ndev = <59>;
+			riscv,max-priority = < 0x07 >;
+			riscv,ndev = < 0x35 >;
+			linux,phandle = < 0x09 >;
+			phandle = < 0x09 >;
 		};
-		L6: itim@1800000 {
+
+		itim@1800000 {
 			compatible = "sifive,itim0";
-			reg = <0x0 0x1800000 0x0 0x4000>;
+			reg = < 0x00 0x1800000 0x00 0x4000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x04 >;
+			phandle = < 0x04 >;
 		};
-		L11: itim@1808000 {
+
+		itim@1808000 {
 			compatible = "sifive,itim0";
-			reg = <0x0 0x1808000 0x0 0x8000>;
+			reg = < 0x00 0x1808000 0x00 0x8000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x05 >;
+			phandle = < 0x05 >;
 		};
-		L15: itim@1810000 {
+
+		itim@1810000 {
 			compatible = "sifive,itim0";
-			reg = <0x0 0x1810000 0x0 0x8000>;
+			reg = < 0x00 0x1810000 0x00 0x8000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x06 >;
+			phandle = < 0x06 >;
 		};
-		L19: itim@1818000 {
+
+		itim@1818000 {
 			compatible = "sifive,itim0";
-			reg = <0x0 0x1818000 0x0 0x8000>;
+			reg = < 0x00 0x1818000 0x00 0x8000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x07 >;
+			phandle = < 0x07 >;
 		};
-		L23: itim@1820000 {
+
+		itim@1820000 {
 			compatible = "sifive,itim0";
-			reg = <0x0 0x1820000 0x0 0x8000>;
+			reg = < 0x00 0x1820000 0x00 0x8000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x08 >;
+			phandle = < 0x08 >;
 		};
-		L38: memory-controller@100b0000 {
-			compatible = "sifive,ux00ddr0";
-			interrupt-parent = <&L2>;
-			interrupts = <32>;
-			reg = <0x0 0x100b0000 0x0 0x4000>;
+
+		memory-controller@100b0000 {
+			compatible = "sifive,aloeddr0";
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x1f >;
+			reg = < 0x00 0x100b0000 0x00 0x4000 >;
 			reg-names = "control";
 		};
-		L43: msi@2020000 {
+
+		msi@2020000 {
 			compatible = "sifive,msi0";
-			interrupt-parent = <&L2>;
-			interrupts = <33 34 35 36 37 38 39 40 41 42>;
-			reg = <0x0 0x2020000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x20 0x21 0x22 0x23 0x24 0x25 0x26 0x27 0x28 0x29 >;
+			reg = < 0x00 0x2020000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L42: order-ogler@10100000 {
+
+		order-ogler@10100000 {
 			compatible = "sifive,order-ogler0";
-			reg = <0x0 0x10100000 0x0 0x1000>;
+			reg = < 0x00 0x10100000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L1: physical-filter@100b8000 {
-			compatible = "sifive,physical-filter-v0";
-			reg = <0x0 0x100b8000 0x0 0x1000>;
-			reg-names = "control";
-		};
-		L53: pinctrl@10080000 {
+
+		pinctrl@10080000 {
 			compatible = "sifive,pinctrl0";
-			reg = <0x0 0x10080000 0x0 0x1000>;
+			reg = < 0x00 0x10080000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L48: prci@10000000 {
-			compatible = "sifive,ux00prci0";
-			reg = <0x0 0x10000000 0x0 0x1000>;
+
+		prci@10000000 {
+			compatible = "sifive,aloeprci0";
+			reg = < 0x00 0x10000000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L45: pwm@10020000 {
+
+		pwm@10020000 {
 			compatible = "sifive,pwm0";
-			interrupt-parent = <&L2>;
-			interrupts = <43 44 45 46>;
-			reg = <0x0 0x10020000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x2a 0x2b 0x2c 0x2d >;
+			reg = < 0x00 0x10020000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L46: pwm@10021000 {
+
+		pwm@10021000 {
 			compatible = "sifive,pwm0";
-			interrupt-parent = <&L2>;
-			interrupts = <47 48 49 50>;
-			reg = <0x0 0x10021000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x2e 0x2f 0x30 0x31 >;
+			reg = < 0x00 0x10021000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L31: rom@1000 {
+
+		rom@1000 {
 			compatible = "sifive,modeselect0";
-			reg = <0x0 0x1000 0x0 0x1000>;
+			reg = < 0x00 0x1000 0x00 0x1000 >;
 			reg-names = "mem";
 		};
-		L30: rom@10000 {
+
+		rom@10000 {
 			compatible = "sifive,maskrom0";
-			reg = <0x0 0x10000 0x0 0x8000>;
+			reg = < 0x00 0x10000 0x00 0x8000 >;
 			reg-names = "mem";
 		};
-		L29: rom@a000000 {
+
+		rom@a000000 {
 			compatible = "ucbbar,cacheable-zero0";
-			reg = <0x0 0xa000000 0x0 0x2000000>;
+			reg = < 0x00 0xa000000 0x00 0x2000000 >;
 			reg-names = "mem";
+			linux,phandle = < 0x0a >;
+			phandle = < 0x0a >;
 		};
-		L32: serial@10010000 {
+
+		serial@10010000 {
 			compatible = "sifive,uart0";
-			interrupt-parent = <&L2>;
-			interrupts = <5>;
-			reg = <0x0 0x10010000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x04 >;
+			reg = < 0x00 0x10010000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L33: serial@10011000 {
+
+		serial@10011000 {
 			compatible = "sifive,uart0";
-			interrupt-parent = <&L2>;
-			interrupts = <6>;
-			reg = <0x0 0x10011000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x05 >;
+			reg = < 0x00 0x10011000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L49: spi@10040000 {
+
+		spi@10040000 {
 			compatible = "sifive,spi0";
-			interrupt-parent = <&L2>;
-			interrupts = <52>;
-			reg = <0x0 0x10040000 0x0 0x1000 0x0 0x20000000 0x0 0x10000000>;
-			reg-names = "control", "mem";
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x33 >;
+			reg = < 0x00 0x10040000 0x00 0x1000 0x00 0x20000000 0x00 0x10000000 >;
+			reg-names = "control\0mem";
 		};
-		L50: spi@10041000 {
+
+		spi@10041000 {
 			compatible = "sifive,spi0";
-			interrupt-parent = <&L2>;
-			interrupts = <53>;
-			reg = <0x0 0x10041000 0x0 0x1000 0x0 0x30000000 0x0 0x10000000>;
-			reg-names = "control", "mem";
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x34 >;
+			reg = < 0x00 0x10041000 0x00 0x1000 0x00 0x30000000 0x00 0x10000000 >;
+			reg-names = "control\0mem";
 		};
-		L34: spi@10050000 {
+
+		spi@10050000 {
 			compatible = "sifive,spi0";
-			interrupt-parent = <&L2>;
-			interrupts = <7>;
-			reg = <0x0 0x10050000 0x0 0x1000>;
+			interrupt-parent = < 0x09 >;
+			interrupts = < 0x06 >;
+			reg = < 0x00 0x10050000 0x00 0x1000 >;
 			reg-names = "control";
 		};
-		L26: teststatus@4000 {
+
+		teststatus@4000 {
 			compatible = "sifive,test0";
-			reg = <0x0 0x4000 0x0 0x1000>;
+			reg = < 0x00 0x4000 0x00 0x1000 >;
 			reg-names = "control";
 		};
 	};

--- a/zsbl/ux00boot.o.patch
+++ b/zsbl/ux00boot.o.patch
@@ -1,0 +1,21 @@
+--- zsbl/ux00boot.o.s	2018-09-13 20:04:18.923606723 -0600
++++ zsbl/ux00boot.o.s.2	2018-09-13 20:04:44.275278088 -0600
+@@ -801,16 +801,15 @@
+ 	or	a5,a0,a4
+ .LVL83:
+ .L45:
+-	mv	s0,a1
++	slli	s0,a1,56
++	li	a0,268500992
+ .LVL84:
+ 	.loc 2 491 0
+ 	.LA0: auipc	a1,%pcrel_hi(.LC0)
+ .LVL85:
+ 	addi	a1,a1,%pcrel_lo(.LA0)
+-	li	a0,268500992
+ .LVL86:
+ 	.loc 2 488 0
+-	sll	s0,s0,56
+ .LVL87:
+ 	.loc 2 489 0
+ 	or	s0,s0,a5

--- a/zsbl/ux00boot_ordered.c
+++ b/zsbl/ux00boot_ordered.c
@@ -1,0 +1,7 @@
+#include <ux00boot/ux00boot.c>
+
+int load_spiflash_gpt_partition(spi_ctrl* spictrl, void* dst, const gpt_guid* partition_type_guid) { return _load_spiflash_gpt_partition(spictrl, dst, partition_type_guid); }
+int load_mmap_gpt_partition(const void* gpt_base, void* payload_dest, const gpt_guid* partition_type_guid) { return _load_mmap_gpt_partition(gpt_base, payload_dest, partition_type_guid); }
+int load_sd_gpt_partition(spi_ctrl* spictrl, void* dst, const gpt_guid* partition_type_guid) { return _load_sd_gpt_partition(spictrl, dst, partition_type_guid); }
+void ux00boot_fail(long code, int trap) { _ux00boot_fail(code, trap); }
+void ux00boot_load_gpt_partition(void* dst, const gpt_guid* partition_type_guid, unsigned int peripheral_input_khz) { return _ux00boot_load_gpt_partition(dst, partition_type_guid, peripheral_input_khz); }


### PR DESCRIPTION
Using this toolchain:
https://github.com/riscv/riscv-gnu-toolchain/commit/c7fb15341e615e1a1e2fca094ad149bfb7ece16b

SHA256 f9353bab5e826e937783c9ace7411375af9733c454d3d5f9f365509f2f7a4cdb.
`make bootrom.bin` verifies the shasum.

--------

The toolchain given by @tmagik does seem to be close. The relaxation and general compilation is good, but there are a few differences in optimization and codegen. My goal was to make a few small patches that are easy to audit. I've almost succeeded with C tweaks and patching asm, but unfortunately `ux00boot_load_gpt_partition()` comes out wildly different so I've just embedded asm. (I'm bummed to not have a better solution, but at ~20 hours it's starting to not be fun, and I have other responsibilities...)

ux00boot_ordered.c is made so I can re-order the code to match the image, without actually moving text in a way that would be hard to understand and audit.

Thanks to @SirCmpwn for the dts file, @esmil for misc things like some disassembly and segment alignment, and @tmagik for the pointer to a similar toolchain.