### PR TITLE
Strip and remove unneeded sections (objcopy)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ fsbl/dtb.o: fsbl/ux00_fsbl.dtb
 zsbl/start.o: zsbl/ux00_zsbl.dtb
 
 %.bin: %.elf
-	$(OBJCOPY) -O binary $^ $@
+	$(OBJCOPY) -S -R .comment -R .note.gnu.build-id -O binary $^ $@
 
 %.asm: %.elf
 	$(OBJDUMP) -S $^ > $@


### PR DESCRIPTION
Compiling FSBL with OE (linux toolchain, GCC 9.1) resulted in a very
sparse binary with ~129MB apparent size. This is because toolchain was
configured with linker build id by default. Objcopy left GNU build id
section at 0x0. Strip the binary and remove unneeded sections.

The resulting FSBL binary was successfully tested on SiFive Unleashed 
hardware.

Signed-off-by: David Abdurachmanov <david.abdurachmanov@sifive.com>