### PR TITLE
Enable entire L2 cache

### DIFF
--- a/fsbl/start.S
+++ b/fsbl/start.S
@@ -218,3 +218,17 @@ trap_entry:
   csrr  t0,mcause
   add   a0,zero,t0
   j     _fail
+
+/* All L2 cache ways will be enabled in the CCache trmpoline */
+  .global _CCache_trampoline_start
+_CCache_trampoline_start:
+1:
+  fence	rw, io
+  li	t0, CCACHE_CTRL_ADDR
+  addi	t0, t0,CCACHE_ENABLE
+  li	t1, 15
+  amoswap.w t1,t1,(t0)
+  fence io, rw
+  unimp
+  .global _CCache_trampoline_end
+_CCache_trampoline_end:


### PR DESCRIPTION
At runtime, FSBL is located on the lastest way of L2 cache. Therefore,
FSBL can only enable the first 15 L2 cache ways to avoid corrupt itself.
To make FSBL enable entire 16 L2 cache ways, this patch creates a
trampoline before entering the FSBL payload program. At runtime, this
trampoline is located on DRAM. Therefore, FSBL able to enable the entire
L2 cache at the trampoline.