### PR TITLE
Compile without a C library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ CC=${CROSSCOMPILE}gcc
 LD=${CROSSCOMPILE}ld
 OBJCOPY=${CROSSCOMPILE}objcopy
 OBJDUMP=${CROSSCOMPILE}objdump
-CFLAGS=-I. -Ilib/include -O2 -ggdb -march=rv64imafdc -mabi=lp64d -Wall -mcmodel=medany -mexplicit-relocs -ffreestanding
+WARNINGS=-Wall -Wextra -Wshadow -Wformat=2 -Wformat-truncation=2 -Wundef -Wno-unused-parameter
+CPPFLAGS=-I. -Ilib/include
+CFLAGS=-O2 -ggdb -march=rv64imafdc -mabi=lp64d -mcmodel=medany -mexplicit-relocs $(WARNINGS) $(CPPFLAGS) -ffreestanding
 CCASFLAGS=-I. -mcmodel=medany -mexplicit-relocs
 LDFLAGS=-nostdlib -nostartfiles
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CC=${CROSSCOMPILE}gcc
 LD=${CROSSCOMPILE}ld
 OBJCOPY=${CROSSCOMPILE}objcopy
 OBJDUMP=${CROSSCOMPILE}objdump
-CFLAGS=-I. -O2 -ggdb -march=rv64imafdc -mabi=lp64d -Wall -mcmodel=medany -mexplicit-relocs
+CFLAGS=-I. -Ilib/include -O2 -ggdb -march=rv64imafdc -mabi=lp64d -Wall -mcmodel=medany -mexplicit-relocs -ffreestanding
 CCASFLAGS=-I. -mcmodel=medany -mexplicit-relocs
 LDFLAGS=-nostdlib -nostartfiles
 

--- a/fsbl/main.c
+++ b/fsbl/main.c
@@ -5,13 +5,11 @@
 
 #include "encoding.h"
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 #include <stdatomic.h>
 #include "fdt/fdt.h"
 #include <ememoryotp/ememoryotp.h>
 #include <uart/uart.h>
-#include <stdio.h>
 
 #include "regconfig-ctl.h"
 #include "regconfig-phy.h"

--- a/fsbl/main.c
+++ b/fsbl/main.c
@@ -53,7 +53,7 @@ Barrier barrier = { {0, 0}, {0, 0}, 0}; // bss initialization is done by main co
 
 extern const gpt_guid gpt_guid_sifive_bare_metal;
 volatile uint64_t dtb_target;
-unsigned int serial_to_burn = ~0;
+unsigned int serial_to_burn = ~0U;
 
 uint32_t __attribute__((weak)) own_dtb = 42; // not 0xedfe0dd0 the DTB magic
 
@@ -335,7 +335,7 @@ int main(int id, unsigned long dtb)
 #define FIRST_SLOT	0xfe
 #define LAST_SLOT	0x80
 
-  unsigned int serial = ~0;
+  unsigned int serial = ~0U;
   int serial_slot;
   ememory_otp_power_up_sequence();
   ememory_otp_begin_read();
@@ -344,7 +344,7 @@ int main(int id, unsigned long dtb)
     unsigned int neg = ememory_otp_read(serial_slot+1);
     serial = pos;
     if (pos == ~neg) break; // legal serial #
-    if (pos == ~0 && neg == ~0) break; // empty slot encountered
+    if (pos == ~0U && neg == ~0U) break; // empty slot encountered
   }
   ememory_otp_exit_read();
 
@@ -353,12 +353,12 @@ int main(int id, unsigned long dtb)
   uart_put_hex(uart, serial);
 
   // Program the OTP?
-  if (serial_to_burn != ~0 && serial != serial_to_burn && serial_slot > LAST_SLOT) {
+  if (serial_to_burn != ~0U && serial != serial_to_burn && serial_slot > LAST_SLOT) {
     uart_puts(uart, "Programming serial: ");
     uart_put_hex(uart, serial_to_burn);
     uart_puts(uart, "\r\n");
     ememory_otp_pgm_entry();
-    if (serial != ~0) {
+    if (serial != ~0U) {
       // erase the current serial
       uart_puts(uart, "Erasing prior serial\r\n");
       ememory_otp_pgm_access(serial_slot,   0);
@@ -376,7 +376,7 @@ int main(int id, unsigned long dtb)
 
   // SiFive MA-S MAC block; default to serial 0
   unsigned char mac[6] = { 0x70, 0xb3, 0xd5, 0x92, 0xf0, 0x00 };
-  if (serial != ~0) {
+  if (serial != ~0U) {
     mac[5] |= (serial >>  0) & 0xff;
     mac[4] |= (serial >>  8) & 0xff;
     mac[3] |= (serial >> 16) & 0xff;

--- a/fsbl/ux00ddr.h
+++ b/fsbl/ux00ddr.h
@@ -11,7 +11,6 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-#include <unistd.h>
 #include <uart/uart.h>
 #include <sifive/platform.h>
 

--- a/lib/include/string.h
+++ b/lib/include/string.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2020 Emil Renner Berthing */
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* See the file LICENSE for further information */
+
+#ifndef LIB_INCLUDE_STRING_H
+#define LIB_INCLUDE_STRING_H
+
+#include <stddef.h>
+
+void *memset(void *s, int c, size_t n);
+void *memcpy(void *__restrict dest, const void *__restrict src, size_t n);
+
+int strcmp(const char *s1, const char *s2);
+size_t strlen(const char *s);
+
+#endif

--- a/lib/strcmp.S
+++ b/lib/strcmp.S
@@ -14,10 +14,28 @@
    http://www.opensource.org/licenses.
 */
 
-#include <sys/asm.h>
-
-#if BYTE_ORDER != LITTLE_ENDIAN
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
 # error
+#endif
+
+#ifndef SZREG
+# if __riscv_xlen == 64
+#  define SZREG 8
+# elif __riscv_xlen == 32
+#  define SZREG 4
+# else
+#  error
+# endif
+#endif
+
+#ifndef REG_L
+# if __riscv_xlen == 64
+#  define REG_L ld
+# elif __riscv_xlen == 32
+#  define REG_L lw
+# else
+#  error
+# endif
 #endif
 
 .text

--- a/lib/strlen.c
+++ b/lib/strlen.c
@@ -17,6 +17,14 @@
 #include <string.h>
 #include <stdint.h>
 
+static __inline unsigned long detect_null(unsigned long w)
+{
+  unsigned long mask = 0x7f7f7f7f;
+  if (sizeof (long) == 8)
+    mask = ((mask << 16) << 16) | mask;
+  return ~(((w & mask) + mask) | w | mask);
+}
+
 size_t strlen(const char *str)
 {
   const char *start = str;
@@ -35,7 +43,7 @@ size_t strlen(const char *str)
     } while ((uintptr_t)str & (sizeof (long) - 1));
 
   unsigned long *ls = (unsigned long *)str;
-  while (!__libc_detect_null (*ls++))
+  while (!detect_null (*ls++))
     ;
   asm volatile ("" : "+r"(ls)); /* prevent "optimization" */
 

--- a/sd/sd.c
+++ b/sd/sd.c
@@ -237,17 +237,20 @@ int sd_copy(spi_ctrl* spi, void* dst, uint32_t src_lba, size_t size)
   long i = size;
   int rc = 0;
 
-  uint8_t crc = 0;
-  crc = crc7(crc, SD_CMD(SD_CMD_READ_BLOCK_MULTIPLE));
-  crc = crc7(crc, src_lba >> 24);
-  crc = crc7(crc, (src_lba >> 16) & 0xff);
-  crc = crc7(crc, (src_lba >> 8) & 0xff);
-  crc = crc7(crc, src_lba & 0xff);
-  crc = (crc << 1) | 1;
-  if (sd_cmd(spi, SD_CMD(SD_CMD_READ_BLOCK_MULTIPLE), src_lba, crc) != 0x00) {
-    sd_cmd_end(spi);
-    return SD_COPY_ERROR_CMD18;
+  {
+    uint8_t crc = 0;
+    crc = crc7(crc, SD_CMD(SD_CMD_READ_BLOCK_MULTIPLE));
+    crc = crc7(crc, src_lba >> 24);
+    crc = crc7(crc, (src_lba >> 16) & 0xff);
+    crc = crc7(crc, (src_lba >> 8) & 0xff);
+    crc = crc7(crc, src_lba & 0xff);
+    crc = (crc << 1) | 1;
+    if (sd_cmd(spi, SD_CMD(SD_CMD_READ_BLOCK_MULTIPLE), src_lba, crc) != 0x00) {
+      sd_cmd_end(spi);
+      return SD_COPY_ERROR_CMD18;
+    }
   }
+
   do {
     uint16_t crc, crc_exp;
     long n;


### PR DESCRIPTION
This repo already contain implementations of memset, memcy, strcmp and strlen, so we just need our own copy of string.h to be able to use -ffreestanding.

This also means we can compile with a riscv64-linux-gnu toolchain which just an apt-get/dnf install/etc. away on most Linux distros.

I've tested this built with both riscv64-unknown-elf and riscv64-linux-gnu toolchains and my HFU still boots.