### PR TITLE
Disable "-ftree-loop-distribute-patterns" compiler optimisation option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CC=${CROSSCOMPILE}gcc
 LD=${CROSSCOMPILE}ld
 OBJCOPY=${CROSSCOMPILE}objcopy
 OBJDUMP=${CROSSCOMPILE}objdump
-CFLAGS=-I. -O2 -ggdb -march=rv64imafdc -mabi=lp64d -Wall -mcmodel=medany -mexplicit-relocs
+CFLAGS=-I. -O2 -ggdb -march=rv64imafdc -mabi=lp64d -Wall -mcmodel=medany -mexplicit-relocs -fno-tree-loop-distribute-patterns
 CCASFLAGS=-I. -mcmodel=medany -mexplicit-relocs
 LDFLAGS=-nostdlib -nostartfiles
 


### PR DESCRIPTION
There is an issue observed wherein the fsbl bootloader stops booting when
compiled against GCC version 10.1.0

The issue is not specifically with GCC version 10.1.0, it can be reproduced
with older GCC version as well by using the optimization level -O3.
Since for FSBL compilation, the default is -O2 level, this issue was not
observed until now. In the recent version of GCC (v10.1.0), some of the
optimization flags are now enabled with -O2 which were previously enabled
with -O3 and one of these flags is "-ftree-loop-distribute-patterns".

The optimization flag "-ftree-loop-distribute-patterns" performs loop
distribution of patterns that can be code generated with calls to a library
like memcpy or memset. In the FSBL code, the loop body inside the memcpy
func in lib/memcpy.c gets replaced (optimized) by a call to memcpy i.e
itself and this results in an infinite loop (a recursive call to memcpy).

To solve this issue, disable this particular optimization flag by using
"-fno-tree-loop-distribute-patterns" while compiling the FSBL code.

Signed-off-by: Yash Shah <yash.shah@sifive.com>